### PR TITLE
Added plugin title in the widget

### DIFF
--- a/dashboard/dashboard.php
+++ b/dashboard/dashboard.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'THEMEISLE_DASHBOARD' ) ) {
 		 * Setup class variables
 		 */
 		public function setup_vars() {
-			$this->dashboard_name = apply_filters( 'themeisle_sdk_dashboard_widget_name', 'WordPress Guides/Tutorials' );
+			$this->dashboard_name = apply_filters( 'themeisle_sdk_dashboard_widget_name', '[Login Customizer] WordPress Guides/Tutorials' );
 			$this->feeds          = apply_filters( 'themeisle_sdk_dashboard_widget_feeds', array(
 				'https://themeisle.com/blog/feed'
 			) );


### PR DESCRIPTION
As per Plugin Guidelines, added plugin name to the widget to make it clear for users. https://github.com/Codeinwp/login-customizer/issues/28

@selul Hopefully we can release this update soon so we don't get kicked out of the repo. :D