### PR TITLE
login_headertitle → login_headertext for accessibility

### DIFF
--- a/inc/customizer/functions.php
+++ b/inc/customizer/functions.php
@@ -31,8 +31,8 @@ function logincust_login_logo_url_title() {
 	return $title;
 }
 
-// Hook to login_headertitle
-add_filter( 'login_headertitle', 'logincust_login_logo_url_title' );
+// Hook to login_headertext
+add_filter( 'login_headertext', 'logincust_login_logo_url_title' );
 
 /**
  * Remove register link

--- a/inc/template-login-customizer.php
+++ b/inc/template-login-customizer.php
@@ -53,7 +53,7 @@ if ( is_multisite() ) {
 
 	$login_header_url = apply_filters( 'login_headerurl', $login_header_url );
 
-	$login_header_title = apply_filters( 'login_headertitle', $login_header_title );
+	$login_header_title = apply_filters( 'login_headertext', $login_header_title );
 
 if ( is_multisite() ) {
 	$login_header_text = get_bloginfo( 'name', 'display' );


### PR DESCRIPTION
Use `login_headertext` instead of the [deprecated](https://developer.wordpress.org/reference/hooks/login_headertitle/#content-area) `login_headertitle`, for accessibility without changing functionality.